### PR TITLE
Separate normal Menu from Structural Menu

### DIFF
--- a/pymenus/menu.py
+++ b/pymenus/menu.py
@@ -35,7 +35,7 @@ class Option(BaseModel):
 
 
 
-class _BaseMenu:
+class _BaseMenu(BaseModel):
     @abstractmethod
     def __repr__(self) -> str:
         ...
@@ -152,7 +152,7 @@ class _BaseMenu:
 
 
 
-class Menu(BaseModel,_BaseMenu):
+class Menu(_BaseMenu):
     """
     Menu object prompts the user to navigate to different sub-menus/options of the app.
 

--- a/pymenus/menu.py
+++ b/pymenus/menu.py
@@ -135,20 +135,16 @@ class _BaseMenu(BaseModel):
         elif selected_option is None:
             exit()
         to_call,defined_kwargs = selected_option
-        if isinstance(to_call, self.__class__):
+        if isinstance(to_call, _BaseMenu):
             to_call.execute(**(kwargs if kwargs else defined_kwargs))
         elif isinstance(to_call, Option):
             rx.cls()
             to_call.function(**(kwargs if kwargs else defined_kwargs))
             rx.getpass("\nPress enter to continue...")
         else:
-            print(selected_option)
             raise TypeError("Invalid type returned by `get_user_input()`")
 
         self.execute(**kwargs)
-
-
-
 
 
 

--- a/pymenus/menu.py
+++ b/pymenus/menu.py
@@ -249,7 +249,7 @@ class Menu(_BaseMenu):
         if isinstance(selected_option, Menu):
             return (selected_option, {})
         elif isinstance(selected_option, Option):
-            return (selected_option.function, selected_option.kwargs)
+            return (selected_option, selected_option.kwargs)
 
 
     def add_submenus(self, *sub_menus:"Menu") -> None:
@@ -292,3 +292,103 @@ class Menu(_BaseMenu):
         Menu._validate_structure(structure, title=title)
         menu._structure = structure
         return menu
+
+
+
+class StructuralMenu(_BaseMenu):
+    """
+    Menu object prompts the user to navigate to different sub-menus/options of the app.
+
+    You can add sub_menus and options using `add_submenus` and `add_options`
+
+    Each menu can be run via `execute` method.
+    (When user selects a sub-menu, `execute` method of the sub-menu will be called automatically)
+
+    Args (keyword-only):
+
+        title (str): Title will be shown in the list of options
+
+        prompt_text (str): This will be the prompt shown to user when they are in the menu, defaults to title
+
+    """
+    title: str
+    structure: list
+    prompt_text: Optional[str] = None
+
+
+    @validator("prompt_text", always=True)
+    def _validate_prompt_text(cls, value, values):
+        if value is None:
+            return values["title"] + "> "
+        else:
+            return value
+
+    @validator("structure")
+    def _validate_structure(cls, structure, **values):
+        for section in structure:
+            if not isinstance(section, (_BaseMenu,Option,str,int)):
+                raise TypeError(f"Wrong value in menu structure ({values['title']})")
+        return structure
+
+    def __repr__(self) -> str:
+        return f"StructuralMenu(title='{self.title}', structure=...)"
+    def __str__(self) -> str:
+        return repr(self)
+
+
+    def _display_prompt(self) -> list[Any]:
+        if not self.structure:
+            print("Empty Menu")
+            rx.getpass("\nPress enter to continue...")
+            return False
+        if not all([isinstance(section,(_BaseMenu,Option,str,int)) for section in self.structure]):
+            raise TypeError(f"Wrong value in menu structure ({self.title})")
+
+        i = 1
+        for section in self.structure:
+            if isinstance(section, (_BaseMenu,Option)):
+                print(f"   {i}) {section.title}")
+                i+=1
+            elif isinstance(section,str):
+                print(section)
+            elif isinstance(section,int):
+                if section != BACK_BUTTON:
+                    raise ValueError(f"Invalid structure: `{section}` in menu `{self.title}`")
+                print("   0) Back")
+        return self._generate_user_input_structure()
+
+    def _prompt(self, input_structure:dict=None) -> int|None:
+        print()
+        try:
+            choice = rx.io.selective_input(
+                self.prompt_text,
+                choices = [str(i) for i in input_structure.keys()],
+                post_action = int
+            )
+        except (EOFError, KeyboardInterrupt):
+            return None
+        return choice
+
+    def _handle_input(self, input_structure:dict[int,Any], number:int) -> tuple[Callable|_BaseMenu, dict] | None:
+        if number is None:
+            return None
+        assert number in input_structure, "Internal error in _prompt() and _handle_input()"
+        if number == 0:
+            return False
+        selected_option = input_structure[number]
+        if isinstance(selected_option, _BaseMenu):
+            return (selected_option, {})
+        elif isinstance(selected_option, Option):
+            return (selected_option, selected_option.kwargs)
+
+
+    def _generate_user_input_structure(self):
+        i = 1
+        user_input_structure = {}
+        for section in self.structure:
+            if isinstance(section, (_BaseMenu,Option)):
+                user_input_structure[i] = section
+                i+=1
+            elif isinstance(section,int):
+                user_input_structure[0] = BACK_BUTTON
+        return user_input_structure


### PR DESCRIPTION
fixed #4 
- Added a `_BaseMenu` which all menu classes must inherit from it. 
- Separated `Menu` and `StructuralMenu` so the code is less confusing